### PR TITLE
Parallelize Postgres event parsing

### DIFF
--- a/.boxed.yaml
+++ b/.boxed.yaml
@@ -1,0 +1,17 @@
+# Boxed project config.
+# Edit the defaults below for this project.
+
+exposed-ports: []
+#   - 9000
+#   - 9001
+
+host-postgres:
+  enabled: true
+  port: 5432
+
+worktree:
+  after-create: ""
+#  after-create: |
+#     if [ -f "$BOXED_SOURCE_REPO/.env.local" ] && [ ! -e .env.local ]; then
+#       cp -p "$BOXED_SOURCE_REPO/.env.local" .env.local
+#     fi

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist-newstyle/
 .repro
 ai_docs
 .claude/settings.local.json
+.pc-logs
+ghcid.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Development Workflow
+
+Use `process-compose` for the normal build, test, benchmark, and live-feedback workflow in this repository.
+
+Before starting a new `process-compose` session, always try to attach to an already running session:
+
+```bash
+process-compose attach
+```
+
+Only start a new session when attaching fails because no session is running:
+
+```bash
+process-compose up
+```
+
+The configured process graph lives in `process-compose.yaml`. It includes dependency setup, full builds, tests, benchmarks, and `ghcid` live feedback.
+
+Useful checks:
+
+```bash
+process-compose -f process-compose.yaml --dry-run
+process-compose graph
+process-compose process list
+```

--- a/cabal.project
+++ b/cabal.project
@@ -4,7 +4,43 @@ packages:
   domaindriven/
   domaindriven-examples/
 
--- Use Stackage LTS 24.2 as the main package source
-import: https://www.stackage.org/lts-24.31/cabal.config
-
 with-compiler: ghc-9.10.3
+
+-- Pin the Hackage index so transitive dependency resolution is reproducible.
+index-state: 2026-06-03T08:44:08Z
+
+-- Lower bounds track the versions we actually build against (we do not support
+-- anything older); upper bounds allow future minor/patch releases up to the
+-- next major.
+constraints:
+  aeson >=2.2.5 && <2.3,
+  crypton >=1.0.6 && <1.1,
+  crypton-x509 >=1.7.7 && <1.8,
+  criterion >=1.6.5 && <1.7,
+  effectful >=2.6.1 && <2.7,
+  effectful-core >=2.6.1 && <2.7,
+  effectful-plugin >=2.0.0.1 && <2.1,
+  effectful-th >=1.0.0.3 && <1.1,
+  generic-lens >=2.3.0 && <2.4,
+  generics-sop >=0.5.1.4 && <0.6,
+  hspec >=2.11.17 && <2.12,
+  jose >=0.11 && <0.12,
+  memory >=0.18 && <0.19,
+  microlens >=0.4.14 && <0.5,
+  openapi3 >=3.2.5 && <3.3,
+  optics-core >=0.4.2 && <0.5,
+  optics-extra >=0.4.2.1 && <0.5,
+  postgresql-simple >=0.7.0.1 && <0.8,
+  resource-pool >=0.4.0 && <0.5,
+  servant >=0.20.3 && <0.21,
+  servant-auth >=0.4.2 && <0.4.3,
+  servant-auth-server >=0.4.9.1 && <0.4.10,
+  servant-client-core >=0.20.3 && <0.21,
+  servant-openapi3 >=2.0.1.6 && <2.1,
+  servant-server >=0.20.3 && <0.21,
+  streamly >=0.11.1 && <0.12,
+  streamly-core >=0.3.1 && <0.4,
+  unliftio >=0.2.25.1 && <0.3,
+  unliftio-pool >=0.4.3.1 && <0.5,
+  uuid >=1.3.16 && <1.4,
+  warp >=3.4.13 && <3.5

--- a/domaindriven-core/ChangeLog.md
+++ b/domaindriven-core/ChangeLog.md
@@ -1,5 +1,27 @@
 # Changelog for domaindriven
 
+## 0.6.0
+
+- **Breaking:** event types now require an `NFData` instance. This is enforced
+  uniformly via a superclass on `ReadModel` (and therefore `WriteModel`), so it
+  applies to every backend. For most event types `deriving (Generic, NFData)`
+  is enough.
+- Postgres event parsing is now performed in parallel across worker threads.
+  The number of parser workers is configurable via the new `parseConcurrency`
+  field on `PostgresEvent` (defaults to `getNumCapabilities`); parsed events are
+  fully forced (`NFData`) off the consuming thread. Requires a threaded runtime
+  (`-threaded -with-rtsopts=-N`) to benefit; harmless otherwise. Each fetched
+  batch is split into `chunkSize \`div\` parseConcurrency`-row tasks across the
+  workers, so `chunkSize` now governs both the Postgres round-trip size and the
+  parse-task granularity. The default `chunkSize` was raised from 50 to 2048 so
+  that parallel parsing engages on the streaming/refresh read paths out of the
+  box.
+- Postgres now selects the event column as `event::text` and decodes from a
+  strict `ByteString`. For `jsonb` columns this means the decoded bytes are
+  Postgres's normalized JSON (keys reordered, whitespace stripped, numbers
+  re-rendered) — semantically identical for any `FromJSON` instance, but worth
+  noting for byte-sensitive consumers.
+
 ## 0.5.0
 
 First release published on hackage.

--- a/domaindriven-core/benchmark/ParallelEventParsing.hs
+++ b/domaindriven-core/benchmark/ParallelEventParsing.hs
@@ -1,0 +1,251 @@
+module Main where
+
+import Control.Concurrent (getNumCapabilities)
+import Control.DeepSeq (NFData (..), deepseq, force)
+import Control.Exception (evaluate)
+import Criterion.Main
+import Data.Aeson
+import Data.Bits (xor, (.&.))
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.List (nub)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Time
+import Data.UUID (nil)
+import DomainDriven.Persistance.Class
+import DomainDriven.Persistance.Postgres.Internal (defaultReadChunkSize, parseEventRows)
+import DomainDriven.Persistance.Postgres.Types
+    ( EventNumber (..)
+    , EventRowOut (..)
+    , ParseConcurrency
+    , fromEventRowResult
+    )
+import GHC.Generics (Generic)
+import UnliftIO (pooledMapConcurrentlyN, throwIO)
+import Prelude
+
+type BenchModel = Int
+
+newtype BenchRows = BenchRows [EventRowOut]
+
+instance NFData BenchRows where
+    rnf (BenchRows rows) = forceEventRows rows
+
+data BenchEvent = BenchEvent
+    { delta :: !Int
+    , unusedChecksum :: !Int
+    }
+    deriving stock (Show, Generic)
+    deriving anyclass (NFData)
+
+instance FromJSON BenchEvent where
+    parseJSON = withObject "BenchEvent" $ \o -> do
+        delta <- o .: "delta"
+        payload <- o .: "payload"
+        pure $! BenchEvent{delta, unusedChecksum = payloadChecksum payload}
+
+data BenchPayload = BenchPayload
+    { title :: !Text
+    , tags :: ![Text]
+    , measurements :: ![BenchMeasurement]
+    , nested :: !BenchNested
+    }
+    deriving stock (Show, Generic)
+    deriving anyclass (FromJSON, ToJSON, NFData)
+
+data BenchMeasurement = BenchMeasurement
+    { metricId :: !Int
+    , metricName :: !Text
+    , samples :: ![Int]
+    }
+    deriving stock (Show, Generic)
+    deriving anyclass (FromJSON, ToJSON, NFData)
+
+data BenchNested = BenchNested
+    { groupName :: !Text
+    , leaves :: ![BenchLeaf]
+    }
+    deriving stock (Show, Generic)
+    deriving anyclass (FromJSON, ToJSON, NFData)
+
+data BenchLeaf = BenchLeaf
+    { leafId :: !Int
+    , leafName :: !Text
+    , leafEnabled :: !Bool
+    }
+    deriving stock (Show, Generic)
+    deriving anyclass (FromJSON, ToJSON, NFData)
+
+eventCount :: Int
+eventCount = 10000
+
+payloadWidth :: Int
+payloadWidth = 48
+
+parseWorkIterations :: Int
+parseWorkIterations = 4
+
+eventTimestamp :: UTCTime
+eventTimestamp = UTCTime (fromGregorian 2026 1 1) 0
+
+-- | Worker counts to benchmark, capped at the capabilities the RTS was given
+-- (@-N@). Includes high counts (14, 16) because heterogeneous cores (P/E) can
+-- scale differently than low counts.
+workerCounts :: Int -> [Int]
+workerCounts capabilities =
+    nub [max 1 (min capabilities w) | w <- [1, 4, 14, 16]]
+
+main :: IO ()
+main = do
+    capabilities <- getNumCapabilities
+    let expected = eventCount
+    defaultMain
+        [ env setupRows $ \(BenchRows rows) ->
+            bgroup
+                "compute state from JSON events"
+                [ bgroup
+                    ("workers=" <> show w)
+                    [ bench "streamly" $
+                        nfIO $
+                            expectState expected =<< computeStateWith streamlyStrategy w rows
+                    , bench "pooled" $
+                        nfIO $
+                            expectState expected =<< computeStateWith parseEventRowsPooled w rows
+                    ]
+                | w <- workerCounts capabilities
+                ]
+        ]
+
+setupRows :: IO BenchRows
+setupRows =
+    evaluate $
+        let rows = mkRows eventCount
+         in forceEventRows rows `seq` BenchRows rows
+
+mkRows :: Int -> [EventRowOut]
+mkRows count =
+    [ EventRowOut
+        nil
+        (EventNumber $ fromIntegral i)
+        eventTimestamp
+        (mkEventValue i)
+    | i <- [1 .. count]
+    ]
+
+mkEventValue :: Int -> ByteString
+mkEventValue i =
+    LBS.toStrict
+        . encode
+        $ object
+            [ "delta" .= (1 :: Int)
+            , "payload" .= mkPayload i
+            ]
+
+mkPayload :: Int -> BenchPayload
+mkPayload i =
+    BenchPayload
+        { title = T.pack ("event-" <> show i)
+        , tags = [T.pack ("tag-" <> show j) | j <- [1 .. payloadWidth]]
+        , measurements =
+            [ BenchMeasurement
+                { metricId = i * payloadWidth + j
+                , metricName = T.pack ("metric-" <> show i <> "-" <> show j)
+                , samples = [i, j, i + j, i * j]
+                }
+            | j <- [1 .. payloadWidth]
+            ]
+        , nested =
+            BenchNested
+                { groupName = T.pack ("group-" <> show (i `mod` 17))
+                , leaves =
+                    [ BenchLeaf
+                        { leafId = i * payloadWidth + j
+                        , leafName = T.pack ("leaf-" <> show i <> "-" <> show j)
+                        , leafEnabled = j `mod` 2 == 0
+                        }
+                    | j <- [1 .. payloadWidth]
+                    ]
+                }
+        }
+
+forceEventRows :: [EventRowOut] -> ()
+forceEventRows = foldr forceRow ()
+  where
+    forceRow :: EventRowOut -> () -> ()
+    forceRow (EventRowOut eventId eventNumber eventTime eventValue) rest =
+        eventId `seq` eventNumber `seq` eventTime `seq` eventValue `deepseq` rest
+
+-- | A parsing strategy: turn raw rows into parsed events using @workers@ parser
+-- threads. Lets the benchmark compare the streamly implementation
+-- ('parseEventRows') head-to-head with a hand-rolled 'pooledMapConcurrentlyN'.
+type ParseStrategy =
+    ParseConcurrency -> [EventRowOut] -> IO [(Stored BenchEvent, EventNumber)]
+
+computeStateWith :: ParseStrategy -> ParseConcurrency -> [EventRowOut] -> IO BenchModel
+computeStateWith parse workers rows = do
+    parsed <- parse workers rows
+    let result = foldl' applyBenchEvent 0 parsed
+    result `seq` pure result
+
+-- | The streamly parser under test, fed the production default chunk size so
+-- the per-task granularity (@chunkSize \`div\` workers@) matches real reads.
+streamlyStrategy :: ParseStrategy
+streamlyStrategy workers = parseEventRows workers defaultReadChunkSize
+
+-- | Baseline parser using a hand-rolled thread pool, mirroring the
+-- pre-streamly implementation, for head-to-head comparison.
+parseEventRowsPooled :: ParseStrategy
+parseEventRowsPooled workers rows = do
+    parsed <-
+        if workers <= 1
+            then traverse parseRow rows
+            else pooledMapConcurrentlyN workers parseRow rows
+    either throwIO pure (sequence parsed)
+  where
+    parseRow = evaluate . force . fromEventRowResult @BenchEvent
+
+applyBenchEvent :: BenchModel -> (Stored BenchEvent, EventNumber) -> BenchModel
+applyBenchEvent model (stored, _) = model + delta (storedEvent stored)
+
+expectState :: BenchModel -> BenchModel -> IO BenchModel
+expectState expected actual
+    | actual == expected = pure actual
+    | otherwise = fail $ "Expected state " <> show expected <> ", got " <> show actual
+
+payloadChecksum :: BenchPayload -> Int
+payloadChecksum payload =
+    burnChecksum parseWorkIterations (payloadShapeChecksum payload)
+
+payloadShapeChecksum :: BenchPayload -> Int
+payloadShapeChecksum BenchPayload{title, tags, measurements, nested} =
+    T.length title
+        + foldl' (\total tag -> total + T.length tag) 0 tags
+        + foldl' (\total measurement -> total + measurementChecksum measurement) 0 measurements
+        + nestedChecksum nested
+
+burnChecksum :: Int -> Int -> Int
+burnChecksum iterations seed = go iterations seed
+  where
+    go remaining acc
+        | remaining <= 0 = acc
+        | otherwise =
+            let acc' = ((acc * 1664525) `xor` (acc + 1013904223)) .&. 0x3fffffff
+             in acc' `seq` go (remaining - 1) acc'
+
+measurementChecksum :: BenchMeasurement -> Int
+measurementChecksum BenchMeasurement{metricId, metricName, samples} =
+    metricId
+        + T.length metricName
+        + foldl' (+) 0 samples
+
+nestedChecksum :: BenchNested -> Int
+nestedChecksum BenchNested{groupName, leaves} =
+    T.length groupName
+        + foldl' (\total leaf -> total + leafChecksum leaf) 0 leaves
+
+leafChecksum :: BenchLeaf -> Int
+leafChecksum BenchLeaf{leafId, leafName, leafEnabled} =
+    leafId
+        + T.length leafName
+        + if leafEnabled then 1 else 0

--- a/domaindriven-core/domaindriven-core.cabal
+++ b/domaindriven-core/domaindriven-core.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.12
 
 name:           domaindriven-core
-version:        0.5.0
+version:        0.6.0
 synopsis:       Batteries included event sourcing and CQRS
 description:    Please see the README on GitHub at <https://github.com/tommyengstrom/domaindriven#readme>
 category:       Web
@@ -85,6 +85,7 @@ library
   build-depends:
       aeson
     , base
+    , bytestring
     , containers
     , deepseq
     , exceptions
@@ -120,7 +121,9 @@ test-suite domaindriven-core-test
   build-depends:
       aeson
     , base
+    , bytestring
     , containers
+    , deepseq
     , domaindriven-core
     , hspec
     , postgresql-simple
@@ -129,4 +132,26 @@ test-suite domaindriven-core-test
     , time
     , unliftio
     , unliftio-pool
+    , uuid
+
+benchmark parallel-event-parsing
+  import: default_opts
+  type: exitcode-stdio-1.0
+  main-is: ParallelEventParsing.hs
+  hs-source-dirs:
+      benchmark
+  ghc-options:
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , criterion
+    , deepseq
+    , domaindriven-core
+    , text
+    , time
+    , unliftio
     , uuid

--- a/domaindriven-core/src/DomainDriven/Persistance/Class.hs
+++ b/domaindriven-core/src/DomainDriven/Persistance/Class.hs
@@ -23,7 +23,15 @@ newtype Indexed = Indexed Text
     deriving stock (Show, Generic)
     deriving newtype (Eq, Ord, Hashable)
 
-class ReadModel p where
+-- | Read access to an event-sourced model.
+--
+-- The event type @'Event' p@ must have an 'NFData' instance. The Postgres
+-- backend uses it to fully force freshly parsed events on the parsing worker
+-- threads (rather than on the consuming thread); the requirement is imposed
+-- uniformly on every backend so that event types are interchangeable across
+-- backends. Deriving it is cheap — @deriving (Generic, NFData)@ for most
+-- event types.
+class NFData (Event p) => ReadModel p where
     type Model p :: Type
     type Event p :: Type
     type Index p :: Type
@@ -84,7 +92,7 @@ data AnyWriteModel model event index
         ) =>
         AnyWriteModel p
 
-instance ReadModel (AnyWriteModel model event index) where
+instance NFData event => ReadModel (AnyWriteModel model event index) where
     type Model (AnyWriteModel model event index) = model
     type Event (AnyWriteModel model event index) = event
     type Index (AnyWriteModel model event index) = index
@@ -93,7 +101,7 @@ instance ReadModel (AnyWriteModel model event index) where
     getEventList (AnyWriteModel p) = getEventList p
     getEventStream (AnyWriteModel p) = getEventStream p
 
-instance WriteModel (AnyWriteModel model event index) where
+instance NFData event => WriteModel (AnyWriteModel model event index) where
     postUpdateHook (AnyWriteModel p) = postUpdateHook p
     transactionalUpdate (AnyWriteModel p) = transactionalUpdate p
 

--- a/domaindriven-core/src/DomainDriven/Persistance/ForgetfulInMemory.hs
+++ b/domaindriven-core/src/DomainDriven/Persistance/ForgetfulInMemory.hs
@@ -2,6 +2,7 @@
 
 module DomainDriven.Persistance.ForgetfulInMemory where
 
+import Control.DeepSeq (NFData)
 import Data.Generics.Labels ()
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HM
@@ -37,7 +38,7 @@ data ForgetfulInMemory model index event = ForgetfulInMemory
     }
     deriving (Generic)
 
-instance Hashable index => ReadModel (ForgetfulInMemory model index event) where
+instance (Hashable index, NFData event) => ReadModel (ForgetfulInMemory model index event) where
     type Model (ForgetfulInMemory model index event) = model
     type Event (ForgetfulInMemory model index event) = event
     type Index (ForgetfulInMemory model index event) = index
@@ -55,7 +56,7 @@ instance Hashable index => ReadModel (ForgetfulInMemory model index event) where
             (const (pure ()))
             Stream.fromList
 
-instance Hashable index => WriteModel (ForgetfulInMemory model index event) where
+instance (Hashable index, NFData event) => WriteModel (ForgetfulInMemory model index event) where
     postUpdateHook p index model events = liftIO $ updateHook p index model events
     transactionalUpdate ff index evalCmd =
         bracket_ (waitQSem $ lock ff) (signalQSem $ lock ff) $ do

--- a/domaindriven-core/src/DomainDriven/Persistance/Postgres.hs
+++ b/domaindriven-core/src/DomainDriven/Persistance/Postgres.hs
@@ -19,5 +19,6 @@ import DomainDriven.Persistance.Postgres.Types as X
     , EventTableBaseName
     , EventTableName
     , IsPgIndex (..)
+    , ParseConcurrency
     , PreviousEventTableName
     )

--- a/domaindriven-core/src/DomainDriven/Persistance/Postgres/Internal.hs
+++ b/domaindriven-core/src/DomainDriven/Persistance/Postgres/Internal.hs
@@ -1,6 +1,9 @@
 -- | Postgres events with state as an IORef
 module DomainDriven.Persistance.Postgres.Internal where
 
+import Control.Concurrent (getNumCapabilities)
+import Control.DeepSeq (NFData, force)
+import Control.Exception (evaluate)
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
@@ -74,7 +77,10 @@ data PostgresEvent index model event = PostgresEvent
     , app :: model -> Stored event -> model
     , seed :: model
     , chunkSize :: ChunkSize
-    -- ^ Number of events read from postgres per batch
+    -- ^ Number of events fetched from Postgres per cursor batch. A round-trip /
+    -- memory knob, independent of parse parallelism.
+    , parseConcurrency :: ParseConcurrency
+    -- ^ Number of parser threads that parse a fetched batch concurrently.
     , updateHook
         :: PostgresEvent index model event
         -> index
@@ -92,12 +98,15 @@ data PostgresEventTrans index model event = PostgresEventTrans
     , app :: model -> Stored event -> model
     , seed :: model
     , chunkSize :: ChunkSize
+    -- ^ Number of events fetched from Postgres per cursor batch. A round-trip /
+    -- memory knob, independent of parse parallelism.
+    , parseConcurrency :: ParseConcurrency
+    -- ^ Number of parser threads that parse a fetched batch concurrently.
     , logger :: LogEntry -> IO ()
-    -- ^ Number of events read from postgres per batch
     }
     deriving (Generic)
 
-instance (IsPgIndex i, FromJSON e) => ReadModel (PostgresEvent i m e) where
+instance (IsPgIndex i, FromJSON e, NFData e) => ReadModel (PostgresEvent i m e) where
     type Model (PostgresEvent i m e) = m
     type Index (PostgresEvent i m e) = i
     type Event (PostgresEvent i m e) = e
@@ -105,7 +114,13 @@ instance (IsPgIndex i, FromJSON e) => ReadModel (PostgresEvent i m e) where
     getModel pg index = liftIO $ withIOTrans pg (`getModel'` index)
 
     getEventList pg index = withResource (connectionPool pg) $ \conn ->
-        fmap fst <$> queryEvents (Pool.resource conn) (pg ^. field @"eventTableName") index
+        fmap fst
+            <$> queryEventsWithParseConcurrency
+                (pg ^. field @"parseConcurrency")
+                (pg ^. field @"chunkSize")
+                (Pool.resource conn)
+                (pg ^. field @"eventTableName")
+                index
 
     getEventStream pg = withStreamReadTransaction pg . flip getEventStream'
 
@@ -272,6 +287,7 @@ createPostgresPersistance
     -> IO (PostgresEvent index model event)
 createPostgresPersistance pool eventTable app' seed' = do
     ref <- newIORef HM.empty
+    defaultParseConcurrency <- max 1 <$> getNumCapabilities
     pure $
         PostgresEvent
             { connectionPool = pool
@@ -279,7 +295,8 @@ createPostgresPersistance pool eventTable app' seed' = do
             , modelIORef = ref
             , app = app'
             , seed = seed'
-            , chunkSize = 50
+            , chunkSize = defaultReadChunkSize
+            , parseConcurrency = defaultParseConcurrency
             , updateHook = \_ _ _ _ -> pure ()
             , logger = \case
                 e@(DbTransactionDuration dt _) -> when (dt > 1) $ putStrLn $ "[DomainDriven] " <> show e
@@ -288,35 +305,62 @@ createPostgresPersistance pool eventTable app' seed' = do
                 e@(WaitForConnectionDuration dt _) -> when (dt > 0.5) $ putStrLn $ "[DomainDriven] " <> show e
             }
 
+-- | Default number of events fetched per Postgres cursor batch. Also sets the
+-- parse-task granularity: each batch is split into @chunkSize \`div\`
+-- parseConcurrency@-row tasks across the parser threads.
+defaultReadChunkSize :: ChunkSize
+defaultReadChunkSize = 2048
+
 queryEvents
     :: forall a index
-     . (IsPgIndex index, FromJSON a)
+     . (IsPgIndex index, FromJSON a, NFData a)
     => Connection
     -> EventTableName
     -> index
     -> IO [(Stored a, EventNumber)]
-queryEvents conn eventTable index = do
-    traverse fromEventRow =<< query_ conn q
+queryEvents = queryEventsWithParseConcurrency 1 defaultReadChunkSize
+
+queryEventsWithParseConcurrency
+    :: forall a index
+     . (IsPgIndex index, FromJSON a, NFData a)
+    => ParseConcurrency
+    -> ChunkSize
+    -> Connection
+    -> EventTableName
+    -> index
+    -> IO [(Stored a, EventNumber)]
+queryEventsWithParseConcurrency workers chunkSize conn eventTable index = do
+    parseEventRows workers chunkSize =<< query_ conn q
   where
     q :: PG.Query
     q =
-        "select id, event_number,timestamp,event from "
+        "select id, event_number,timestamp,event::text from "
             <> quoteIdent eventTable
             <> " where index = "
             <> toQuery index
             <> " order by event_number"
 
 queryEventsAfter
-    :: FromJSON a
+    :: (FromJSON a, NFData a)
     => Connection
     -> EventTableName
     -> EventNumber
     -> IO [(Stored a, EventNumber)]
-queryEventsAfter conn eventTable (EventNumber lastEvent) =
-    traverse fromEventRow
+queryEventsAfter = queryEventsAfterWithParseConcurrency 1 defaultReadChunkSize
+
+queryEventsAfterWithParseConcurrency
+    :: (FromJSON a, NFData a)
+    => ParseConcurrency
+    -> ChunkSize
+    -> Connection
+    -> EventTableName
+    -> EventNumber
+    -> IO [(Stored a, EventNumber)]
+queryEventsAfterWithParseConcurrency workers chunkSize conn eventTable (EventNumber lastEvent) =
+    parseEventRows workers chunkSize
         =<< query_
             conn
-            ( "select id, event_number,timestamp,event from "
+            ( "select id, event_number,timestamp,event::text from "
                 <> quoteIdent eventTable
                 <> " where event_number > "
                 <> fromString (show lastEvent)
@@ -334,7 +378,7 @@ mkEventsAfterQuery
     -> EventQuery
 mkEventsAfterQuery eventTable index (EventNumber lastEvent) =
     EventQuery $
-        "select id, event_number,timestamp,event from "
+        "select id, event_number,timestamp,event::text from "
             <> quoteIdent eventTable
             <> " where index = "
             <> toQuery index
@@ -345,7 +389,7 @@ mkEventsAfterQuery eventTable index (EventNumber lastEvent) =
 mkEventQuery :: IsPgIndex index => EventTableName -> index -> EventQuery
 mkEventQuery eventTable index =
     EventQuery $
-        "select id, event_number,timestamp,event from "
+        "select id, event_number,timestamp,event::text from "
             <> quoteIdent eventTable
             <> " where index = "
             <> toQuery index
@@ -429,6 +473,7 @@ writeEvents conn eventTable index storedEvents = do
 
 getEventStream'
     :: ( FromJSON event
+       , NFData event
        , IsPgIndex index
        )
     => PostgresEventTrans index model event
@@ -436,7 +481,8 @@ getEventStream'
     -> Stream IO (Stored event)
 getEventStream' pgt index =
     fst
-        <$> mkEventStream
+        <$> mkEventStreamWithParseConcurrency
+            (pgt ^. #parseConcurrency)
             (pgt ^. #chunkSize)
             (pgt ^. #transaction . #connectionResource . #resource)
             (pgt ^. #eventTableName . to (`mkEventQuery` index))
@@ -465,6 +511,7 @@ withStreamReadTransaction pg = Stream.bracket startTrans rollbackTrans
                 , app = pg ^. field @"app"
                 , seed = pg ^. field @"seed"
                 , chunkSize = pg ^. field @"chunkSize"
+                , parseConcurrency = pg ^. field @"parseConcurrency"
                 , logger = pg ^. field @"logger"
                 }
 
@@ -542,16 +589,26 @@ withIOTrans pg f = do
                 , app = pg ^. field @"app"
                 , seed = pg ^. field @"seed"
                 , chunkSize = pg ^. field @"chunkSize"
+                , parseConcurrency = pg ^. field @"parseConcurrency"
                 , logger = pg ^. field @"logger"
                 }
 
 mkEventStream
-    :: FromJSON event
+    :: (FromJSON event, NFData event)
     => ChunkSize
     -> Connection
     -> EventQuery
     -> Stream IO (Stored event, EventNumber)
-mkEventStream chunkSize conn q = do
+mkEventStream = mkEventStreamWithParseConcurrency 1
+
+mkEventStreamWithParseConcurrency
+    :: (FromJSON event, NFData event)
+    => ParseConcurrency
+    -> ChunkSize
+    -> Connection
+    -> EventQuery
+    -> Stream IO (Stored event, EventNumber)
+mkEventStreamWithParseConcurrency parseConcurrency chunkSize conn q = do
     let step :: Cursor.Cursor -> IO (Maybe (Seq EventRowOut, Cursor.Cursor))
         step cursor = do
             r <- Cursor.foldForward cursor chunkSize (\a r -> pure (a :|> r)) Seq.Empty
@@ -563,15 +620,55 @@ mkEventStream chunkSize conn q = do
     Stream.bracketIO
         (Cursor.declareCursor conn (getPgQuery q))
         Cursor.closeCursor
-        ( Stream.mapM fromEventRow
-            . Stream.unfoldMany Unfold.fromList
-            . fmap toList
+        ( Stream.unfoldEach Unfold.fromList
+            . Stream.mapM (parseEventRows parseConcurrency chunkSize . toList)
             . Stream.unfoldrM step
         )
 
+-- | Parse and fully force a single fetched event row. Run on a parser thread so
+-- the (deep) parse cost stays off the consuming thread.
+parseRowResult
+    :: (FromJSON event, NFData event)
+    => EventRowOut
+    -> IO (Either PersistanceError (Stored event, EventNumber))
+parseRowResult = evaluate . force . fromEventRowResult
+
+-- | Parse a batch of fetched event rows, fully forcing each parsed event off the
+-- calling thread. Up to @workers@ parser threads parse concurrently; results are
+-- returned in input order, and the first parse error (by input order) is thrown.
+--
+-- Rows are split into @chunkSize \`div\` workers@-row tasks: roughly one task per
+-- worker per fetched batch, so the parse granularity scales inversely with the
+-- worker count (more cores → more, finer tasks for better balance) and needs no
+-- separate tuning knob. Together with 'Stream.eager' this matches a hand-rolled
+-- thread pool at low core counts and beats it at high core counts.
+parseEventRows
+    :: (FromJSON event, NFData event)
+    => ParseConcurrency
+    -> ChunkSize
+    -> [EventRowOut]
+    -> IO [(Stored event, EventNumber)]
+parseEventRows workers chunkSize rows = do
+    let taskSize = max 1 (chunkSize `div` max 1 workers)
+    parsed <-
+        if workers <= 1
+            then traverse parseRowResult rows
+            else
+                Stream.fold Fold.toList
+                    . Stream.unfoldEach Unfold.fromList
+                    . Stream.parMapM
+                        ( Stream.maxThreads workers
+                            . Stream.eager True
+                            . Stream.ordered True
+                        )
+                        (traverse parseRowResult)
+                    . Stream.foldMany (Fold.take taskSize Fold.toList)
+                    $ Stream.fromList rows
+    either throwM pure (sequence parsed)
+
 getModel'
     :: forall e index m
-     . (IsPgIndex index, FromJSON e)
+     . (IsPgIndex index, FromJSON e, NFData e)
     => PostgresEventTrans index m e
     -> index
     -> IO m
@@ -599,7 +696,7 @@ getCurrentState pg index =
 
 refreshModel
     :: forall i m e
-     . (IsPgIndex i, FromJSON e)
+     . (IsPgIndex i, FromJSON e, NFData e)
     => PostgresEventTrans i m e
     -> i
     -> IO (m, EventNumber)
@@ -607,7 +704,8 @@ refreshModel pgt index = withExclusiveLock pgt index $ do
     -- refresh doesn't write any events but changes the state and thus needs a lock
     NumberedModel model lastEventNo <- getCurrentState pgt index
     let eventStream =
-            mkEventStream
+            mkEventStreamWithParseConcurrency
+                (pgt ^. field @"parseConcurrency")
                 (pgt ^. field @"chunkSize")
                 (pgt ^. field @"transaction" . field @"connectionResource" . field @"resource")
                 (mkEventsAfterQuery (pgt ^. field @"eventTableName") index lastEventNo)
@@ -652,7 +750,7 @@ withExclusiveLock pgt index a = do
         EventTableLockDuration (diffUTCTime t1 t0) (OneLineCallStack callStack)
     pure r
 
-instance (IsPgIndex i, ToJSON e, FromJSON e) => WriteModel (PostgresEvent i m e) where
+instance (IsPgIndex i, ToJSON e, FromJSON e, NFData e) => WriteModel (PostgresEvent i m e) where
     postUpdateHook pg i m e = liftIO $ (pg ^. field @"updateHook") pg i m e
 
     transactionalUpdate pg index cmd = withRunInIO $ \runInIO ->

--- a/domaindriven-core/src/DomainDriven/Persistance/Postgres/Migration.hs
+++ b/domaindriven-core/src/DomainDriven/Persistance/Postgres/Migration.hs
@@ -2,9 +2,11 @@
 
 module DomainDriven.Persistance.Postgres.Migration where
 
+import Control.DeepSeq (NFData)
 import Control.Monad
 import Data.Aeson
 import Data.Foldable
+import Data.IORef
 import Data.Int
 import Database.PostgreSQL.Simple as PG
 import DomainDriven.Persistance.Class
@@ -43,7 +45,7 @@ migrateValue1to1' chunkSize conn prevTName tName f =
 
 migrate1to1
     :: forall index a b
-     . (FromJSON a, ToJSON b, IsPgIndex index)
+     . (FromJSON a, NFData a, ToJSON b, IsPgIndex index)
     => Connection
     -> PreviousEventTableName
     -> EventTableName
@@ -53,7 +55,7 @@ migrate1to1 = migrate1to1' @index defaultChunkSize
 
 migrate1to1'
     :: forall index a b
-     . (FromJSON a, ToJSON b, IsPgIndex index)
+     . (FromJSON a, NFData a, ToJSON b, IsPgIndex index)
     => ChunkSize
     -> Connection
     -> PreviousEventTableName
@@ -65,7 +67,7 @@ migrate1to1' chunkSize conn prevTName tName f = do
 
 migrate1toMany
     :: forall index a b
-     . (FromJSON a, ToJSON b, IsPgIndex index)
+     . (FromJSON a, NFData a, ToJSON b, IsPgIndex index)
     => Connection
     -> PreviousEventTableName
     -> EventTableName
@@ -75,7 +77,7 @@ migrate1toMany = migrate1toMany' @index defaultChunkSize
 
 migrate1toMany'
     :: forall index a b
-     . (FromJSON a, ToJSON b, IsPgIndex index)
+     . (FromJSON a, NFData a, ToJSON b, IsPgIndex index)
     => ChunkSize
     -> Connection
     -> PreviousEventTableName
@@ -87,7 +89,7 @@ migrate1toMany' chunkSize conn prevTName tName f = do
 
 migrate1toManyWithState
     :: forall index a b state
-     . (FromJSON a, ToJSON b, IsPgIndex index)
+     . (FromJSON a, NFData a, ToJSON b, IsPgIndex index)
     => Connection
     -> PreviousEventTableName
     -> EventTableName
@@ -99,6 +101,7 @@ migrate1toManyWithState = migrate1toManyWithState' @index defaultChunkSize
 migrate1toManyWithState'
     :: forall index a b state
      . ( FromJSON a
+       , NFData a
        , ToJSON b
        , IsPgIndex index
        )
@@ -111,13 +114,20 @@ migrate1toManyWithState'
     -> IO ()
 migrate1toManyWithState' chunkSize conn prevTName tName f initialState = do
     indices <- fetchAllIndices conn prevTName :: IO [index]
-    for_ indices $ \i ->
+    for_ indices $ \i -> do
+        stateRef <- newIORef initialState
         Stream.fold (Fold.groupsOf chunkSize Fold.toList (Fold.drainMapM (liftIO . writeIt i)))
-            . Stream.unfoldMany Unfold.fromList
-            . fmap snd
-            $ Stream.scan (Fold.foldl' (f . fst) (initialState, []))
+            . Stream.unfoldEach Unfold.fromList
+            . Stream.mapM (mapMigratedEvents stateRef)
             $ fst <$> mkEventStream chunkSize conn (mkEventQuery prevTName i)
   where
+    mapMigratedEvents :: IORef state -> Stored a -> IO [Stored b]
+    mapMigratedEvents stateRef event = do
+        state <- readIORef stateRef
+        let (newState, events) = f state event
+        newState `seq` writeIORef stateRef newState
+        pure events
+
     writeIt :: index -> [Stored b] -> IO Int64
     writeIt index events =
         PG.executeMany

--- a/domaindriven-core/src/DomainDriven/Persistance/Postgres/Types.hs
+++ b/domaindriven-core/src/DomainDriven/Persistance/Postgres/Types.hs
@@ -5,8 +5,10 @@ module DomainDriven.Persistance.Postgres.Types
     )
 where
 
+import Control.DeepSeq (NFData)
 import Control.Monad.Catch
 import Data.Aeson
+import Data.ByteString (ByteString)
 import Data.Hashable (Hashable)
 import Data.Int
 import Data.Pool.Introspection as Pool
@@ -14,7 +16,6 @@ import Data.String
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time
-import Data.Typeable
 import Data.UUID (UUID)
 import Database.PostgreSQL.Simple (Connection)
 import Database.PostgreSQL.Simple qualified as PG
@@ -34,13 +35,15 @@ quoteIdent name = "\"" <> fromString (concatMap escChar name) <> "\""
 data PersistanceError
     = EncodingError String
     | ValueError String
-    deriving (Show, Eq, Typeable, Exception)
+    deriving stock (Show, Eq, Generic)
+    deriving anyclass (Exception, NFData)
 
 type EventTableBaseName = String
 type EventVersion = Int
 type EventTableName = String
 type PreviousEventTableName = String
 type ChunkSize = Int
+type ParseConcurrency = Int
 
 class Hashable a => IsPgIndex a where
     toPgIndex :: a -> Text -- FIXME: Should not be Text
@@ -64,7 +67,7 @@ data EventTable
 
 newtype EventNumber = EventNumber {unEventNumber :: Int64}
     deriving (Show, Generic)
-    deriving newtype (Eq, Ord, Num)
+    deriving newtype (Eq, Ord, Num, NFData)
 
 instance FF.FromField EventNumber where
     fromField f bs = EventNumber <$> FF.fromField f bs
@@ -92,15 +95,16 @@ data EventRowOut = EventRowOut
     { key :: UUID
     , commitNumber :: EventNumber
     , timestamp :: UTCTime
-    , event :: Value
+    , event :: ByteString
     }
     deriving (Show, Eq, Generic, PG.FromRow)
 
-fromEventRow :: (FromJSON e, MonadThrow m) => EventRowOut -> m (Stored e, EventNumber)
-fromEventRow (EventRowOut evKey no ts ev) = case fromJSON ev of
-    Success a -> pure (Stored a ts evKey, no)
-    Error err ->
-        throwM
+fromEventRowResult
+    :: FromJSON e => EventRowOut -> Either PersistanceError (Stored e, EventNumber)
+fromEventRowResult (EventRowOut evKey no ts ev) = case eitherDecodeStrict' ev of
+    Right a -> a `seq` Right (Stored a ts evKey, no)
+    Left err ->
+        Left
             . EncodingError
             $ "Failed to parse event "
                 <> show evKey
@@ -108,3 +112,6 @@ fromEventRow (EventRowOut evKey no ts ev) = case fromJSON ev of
                 <> err
                 <> "\nWhen trying to parse:\n"
                 <> show ev
+
+fromEventRow :: (FromJSON e, MonadThrow m) => EventRowOut -> m (Stored e, EventNumber)
+fromEventRow = either throwM pure . fromEventRowResult

--- a/domaindriven-core/test/DomainDriven/Persistance/PostgresSpec.hs
+++ b/domaindriven-core/test/DomainDriven/Persistance/PostgresSpec.hs
@@ -5,9 +5,12 @@ module DomainDriven.Persistance.PostgresSpec where
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
-import Control.Exception (SomeException)
+import Control.DeepSeq (NFData (rnf))
+import Control.Exception (SomeException, displayException)
 import Control.Monad
-import Data.Aeson (FromJSON, ToJSON, Value)
+import Data.Aeson (FromJSON (parseJSON), ToJSON, Value, encode, object, withObject, (.:), (.=))
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
 import Data.Foldable
 import Data.List qualified as L
 import Data.Set (Set)
@@ -24,10 +27,17 @@ import DomainDriven.Persistance.Postgres
 import DomainDriven.Persistance.Postgres.Internal
     ( LogEntry (..)
     , getEventTableName
+    , parseEventRows
     , queryEvents
     , writeEvents
     )
 import DomainDriven.Persistance.Postgres.Migration
+import DomainDriven.Persistance.Postgres.Types
+    ( EventNumber (..)
+    , EventRowOut (..)
+    , PersistanceError (..)
+    , quoteIdent
+    )
 import GHC.Generics (Generic)
 import GHC.IO.Unsafe (unsafePerformIO)
 import Streamly.Data.Stream.Prelude qualified as Stream
@@ -60,6 +70,7 @@ eventTable2 = MigrateUsing mig eventTable
 
 spec :: Spec
 spec = do
+    parallelParsingSpec
     aroundAll (setupPersistance noHook) streamingSpec
     aroundAll (setupPersistance noHook) $ do
         writeEventsSpec
@@ -90,7 +101,21 @@ data TestEvent
     = AddOne
     | SubtractOne
     | Reset
-    deriving (Show, Eq, Generic, FromJSON, ToJSON)
+    deriving (Show, Eq, Generic, FromJSON, ToJSON, NFData)
+
+data ForceProbeEvent = ForceProbeEvent ~String
+
+instance FromJSON ForceProbeEvent where
+    parseJSON = withObject "ForceProbeEvent" $ \o -> do
+        shouldThrowOnForce <- o .: "shouldThrowOnForce"
+        let payload =
+                if shouldThrowOnForce
+                    then error "force-probe"
+                    else "ok"
+        pure (ForceProbeEvent payload)
+
+instance NFData ForceProbeEvent where
+    rnf (ForceProbeEvent payload) = rnf payload
 
 applyTestEvent :: TestModel -> Stored TestEvent -> TestModel
 applyTestEvent m ev = case storedEvent ev of
@@ -122,6 +147,7 @@ setupPersistance postHook test = do
     test
         ( p
             { chunkSize = 2
+            , parseConcurrency = 2
             , logger = const $ pure () -- putStrLn . ("[DomainDriven] " <>) . show
             , updateHook = postHook
             }
@@ -139,7 +165,7 @@ setupPersistanceIndexed test = do
             <$> mkDefaultPoolConfig mkTestConn close 1 stripesAndResources
     pool <- newPool poolCfg
     p <- postgresWriteModel pool eventTable applyTestEvent 0
-    test (p{chunkSize = 2}, pool)
+    test (p{chunkSize = 2, parseConcurrency = 2}, pool)
 
 mkTestConn :: IO Connection
 mkTestConn =
@@ -162,6 +188,13 @@ dropEventTables conn = do
     traverse_
         (\t -> execute_ conn ("drop table \"" <> fromString (fromOnly t) <> "\""))
         testTables
+
+dropEventTableChain :: Connection -> EventTable -> IO ()
+dropEventTableChain conn et =
+    traverse_ dropTable (reverse $ tableNames et)
+  where
+    dropTable tableName =
+        void $ execute_ conn ("drop table if exists " <> quoteIdent tableName)
 
 tableNames :: EventTable -> [EventTableName]
 tableNames et = case et of
@@ -200,6 +233,71 @@ writeEventsSpec = describe "queryEvents" $ do
             writeEvents conn (getEventTableName eventTable) NoIndex storedEvs
         evs' <- getEventList p NoIndex
         drop (length evs' - 2) (fmap storedEvent evs') `shouldBe` evs
+
+parallelParsingSpec :: Spec
+parallelParsingSpec = describe "parseEventRows" $ do
+    -- A small chunk size so that, with > parseTaskSize rows, the input is split
+    -- into many concurrent tasks (taskSize = chunkSize `div` workers). With
+    -- workers = 4 this yields ~64-row tasks, so these specs genuinely exercise
+    -- parallel parsing rather than collapsing to a single task.
+    let testChunkSize = 256 :: Int
+        eventCount = 1000 :: Int
+
+    it "preserves event order when parsing in parallel" $ do
+        let ts = UTCTime (fromGregorian 2020 10 15) 0
+            events = take eventCount $ cycle [AddOne, SubtractOne, Reset]
+            rows =
+                zipWith
+                    ( \eventNumber event ->
+                        EventRowOut nil (EventNumber eventNumber) ts (encodeStrict event)
+                    )
+                    [1 ..]
+                    events
+
+        serial <- parseEventRows @TestEvent 1 testChunkSize rows
+        parsedInParallel <- parseEventRows @TestEvent 4 testChunkSize rows
+
+        parsedInParallel `shouldBe` serial
+        fmap snd parsedInParallel `shouldBe` fmap (EventNumber . fromIntegral) [1 .. eventCount]
+        fmap (storedEvent . fst) parsedInParallel `shouldBe` events
+
+    it "throws the first parse error by input order" $ do
+        firstBadUuid <- V4.nextRandom
+        secondBadUuid <- V4.nextRandom
+        let ts = UTCTime (fromGregorian 2020 10 15) 0
+            invalidEvent = encodeStrict $ object ["invalid" .= (1 :: Int)]
+            -- Two bad rows in different concurrent tasks (positions 10 and 600,
+            -- taskSize ~64); the error from the earlier input position must win.
+            rows =
+                [ if i == 10
+                    then EventRowOut firstBadUuid (EventNumber i) ts invalidEvent
+                    else
+                        if i == 600
+                            then EventRowOut secondBadUuid (EventNumber i) ts invalidEvent
+                            else EventRowOut nil (EventNumber i) ts (encodeStrict AddOne)
+                | i <- [1 .. fromIntegral eventCount]
+                ]
+
+        parseEventRows @TestEvent 4 testChunkSize rows `shouldThrow` \case
+            EncodingError msg -> show firstBadUuid `L.isInfixOf` msg
+            ValueError _ -> False
+
+    it "fully forces parsed events before returning" $ do
+        let ts = UTCTime (fromGregorian 2020 10 15) 0
+            row =
+                EventRowOut
+                    nil
+                    1
+                    ts
+                    ( encodeStrict $
+                        object ["shouldThrowOnForce" .= True]
+                    )
+
+        parseEventRows @ForceProbeEvent 1 testChunkSize [row] `shouldThrow` \e ->
+            "force-probe" `L.isInfixOf` displayException (e :: SomeException)
+
+encodeStrict :: ToJSON a => a -> ByteString
+encodeStrict = LBS.toStrict . encode
 
 indexedSpec :: SpecWith (PostgresEvent Indexed TestModel TestEvent, Pool Connection)
 indexedSpec = describe "Indexed models" $ do
@@ -305,7 +403,9 @@ queryEventsSpec = describe "queryEvents" $ do
         event_numbers `shouldSatisfy` (\n -> and $ zipWith (>) (drop 1 n) n)
 
 postHookSpec
-    :: Chan () -> TVar (Set UUID) -> SpecWith (PostgresEvent NoIndex TestModel TestEvent, Pool Connection)
+    :: Chan ()
+    -> TVar (Set UUID)
+    -> SpecWith (PostgresEvent NoIndex TestModel TestEvent, Pool Connection)
 postHookSpec hookDone processedEvents = describe "updateHook" $ do
     it "Ensure we start with empty TVar" $ \_ -> do
         events <- readTVarIO processedEvents
@@ -387,6 +487,88 @@ migrationSpec = describe "migrate1to1" $ do
                 prevExists `shouldBe` True
                 brokenExists `shouldBe` False
             _ -> fail "Unexpectedly lacking table versions!"
+
+    it "migrate1toManyWithState threads state in order and resets it per index" $ \(_p, pool) -> do
+        let statefulTable :: EventTable
+            statefulTable = InitialVersion "test_events_stateful"
+
+            migratedTable :: EventTable
+            migratedTable = MigrateUsing statefulMigration statefulTable
+
+            eventValue :: String -> Value
+            eventValue label = object ["label" .= label]
+
+            storedValue :: Value -> IO (Stored Value)
+            storedValue value =
+                Stored value (UTCTime (fromGregorian 2020 10 15) 0) <$> mkId
+
+            statefulMigration :: PreviousEventTableName -> EventTableName -> Connection -> IO ()
+            statefulMigration prevName name conn =
+                migrate1toManyWithState @Indexed @Value @Value @Int
+                    conn
+                    prevName
+                    name
+                    ( \state stored ->
+                        let state' = state + 1
+                            migrated =
+                                stored
+                                    { storedEvent =
+                                        object
+                                            [ "sequence" .= state'
+                                            , "input" .= storedEvent stored
+                                            ]
+                                    }
+                         in (state', [migrated])
+                    )
+                    0
+
+        withResource pool (`dropEventTableChain` migratedTable)
+        _ <-
+            postgresWriteModelNoMigration
+                pool
+                (getEventTableName statefulTable)
+                (\model _ -> model)
+                ()
+                :: IO (PostgresEvent Indexed () Value)
+
+        aEvents <- traverse (storedValue . eventValue) ["a1", "a2"]
+        bEvents <- traverse (storedValue . eventValue) ["b1"]
+        withResource pool $ \conn -> do
+            void $
+                writeEvents
+                    conn
+                    (getEventTableName statefulTable)
+                    (Indexed "a")
+                    aEvents
+            void $
+                writeEvents
+                    conn
+                    (getEventTableName statefulTable)
+                    (Indexed "b")
+                    bEvents
+
+        _ <-
+            postgresWriteModel
+                pool
+                migratedTable
+                (\model _ -> model)
+                ()
+                :: IO (PostgresEvent Indexed () Value)
+
+        withResource pool $ \conn -> do
+            aMigrated <-
+                fmap (storedEvent . fst)
+                    <$> queryEvents @Value conn (getEventTableName migratedTable) (Indexed "a")
+            bMigrated <-
+                fmap (storedEvent . fst)
+                    <$> queryEvents @Value conn (getEventTableName migratedTable) (Indexed "b")
+
+            aMigrated
+                `shouldBe` [ object ["sequence" .= (1 :: Int), "input" .= eventValue "a1"]
+                           , object ["sequence" .= (2 :: Int), "input" .= eventValue "a2"]
+                           ]
+            bMigrated
+                `shouldBe` [object ["sequence" .= (1 :: Int), "input" .= eventValue "b1"]]
 
 migrationConcurrencySpec
     :: SpecWith (PostgresEvent NoIndex TestModel TestEvent, Pool Connection)

--- a/domaindriven-examples/crm/Event.hs
+++ b/domaindriven-examples/crm/Event.hs
@@ -4,6 +4,7 @@
 -- in the event handler.
 module Event where
 
+import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -20,7 +21,7 @@ data CrmEvent
         , customerEvent :: CustomerEvent
         }
     deriving stock (Show, Generic)
-    deriving anyclass (FromJSON, ToJSON)
+    deriving anyclass (FromJSON, ToJSON, NFData)
 
 --------------------------------------------------------------------------------
 -- Customer-level events
@@ -36,7 +37,7 @@ data CustomerEvent
         , orderEvent :: OrderEvent
         }
     deriving stock (Show, Generic)
-    deriving anyclass (FromJSON, ToJSON)
+    deriving anyclass (FromJSON, ToJSON, NFData)
 
 --------------------------------------------------------------------------------
 -- Order-level events (includes item events as a 3rd level)
@@ -51,4 +52,4 @@ data OrderEvent
     | ItemRemoved {itemId :: ItemId}
     | ItemQuantityChanged {itemId :: ItemId, quantity :: Int}
     deriving stock (Show, Generic)
-    deriving anyclass (FromJSON, ToJSON)
+    deriving anyclass (FromJSON, ToJSON, NFData)

--- a/domaindriven-examples/crm/Types.hs
+++ b/domaindriven-examples/crm/Types.hs
@@ -1,6 +1,7 @@
 -- | Domain primitives — ID newtypes and enumerations.
 module Types where
 
+import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import Data.Map.Strict (Map)
 import Data.Text (Text)
@@ -15,15 +16,15 @@ import Prelude
 
 newtype CustomerId = CustomerId UUID
     deriving stock (Show, Eq, Ord, Generic)
-    deriving newtype (FromJSON, ToJSON, FromJSONKey, ToJSONKey, FromHttpApiData)
+    deriving newtype (FromJSON, ToJSON, FromJSONKey, ToJSONKey, FromHttpApiData, NFData)
 
 newtype OrderId = OrderId UUID
     deriving stock (Show, Eq, Ord, Generic)
-    deriving newtype (FromJSON, ToJSON, FromJSONKey, ToJSONKey, FromHttpApiData)
+    deriving newtype (FromJSON, ToJSON, FromJSONKey, ToJSONKey, FromHttpApiData, NFData)
 
 newtype ItemId = ItemId UUID
     deriving stock (Show, Eq, Ord, Generic)
-    deriving newtype (FromJSON, ToJSON, FromJSONKey, ToJSONKey, FromHttpApiData)
+    deriving newtype (FromJSON, ToJSON, FromJSONKey, ToJSONKey, FromHttpApiData, NFData)
 
 --------------------------------------------------------------------------------
 -- Enumerations
@@ -31,7 +32,7 @@ newtype ItemId = ItemId UUID
 
 data OrderStatus = Pending | Confirmed | Shipped | Cancelled
     deriving stock (Show, Eq, Generic)
-    deriving anyclass (FromJSON, ToJSON)
+    deriving anyclass (FromJSON, ToJSON, NFData)
 
 --------------------------------------------------------------------------------
 -- Entity types

--- a/domaindriven-examples/domaindriven-examples.cabal
+++ b/domaindriven-examples/domaindriven-examples.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.12
 
 name:           domaindriven-examples
-version:        0.5.0
+version:        0.6.0
 synopsis:       Examples for domaindriven
 description:    Examples demonstrating the domaindriven library
 category:       Web
@@ -84,6 +84,7 @@ executable postgres-example
   build-depends:
       aeson
     , base
+    , deepseq
     , domaindriven-core
     , domaindriven
     , effectful
@@ -103,6 +104,7 @@ executable simple-example
   build-depends:
       aeson
     , base
+    , deepseq
     , domaindriven-core
     , domaindriven
     , effectful
@@ -122,6 +124,7 @@ executable fieldname-as-path-example
   build-depends:
       aeson
     , base
+    , deepseq
     , domaindriven-core
     , domaindriven
     , effectful
@@ -148,6 +151,7 @@ executable crm-example
       aeson
     , base
     , containers
+    , deepseq
     , domaindriven-core
     , domaindriven
     , effectful

--- a/domaindriven-examples/fieldname-as-path/Main.hs
+++ b/domaindriven-examples/fieldname-as-path/Main.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 module Main where
 
+import Control.DeepSeq (NFData)
 import Control.Monad (when)
 import Data.Aeson (FromJSON, ToJSON)
 import DomainDriven
@@ -40,7 +41,7 @@ data CounterModel = CounterModel
 data CounterEvent
     = CounterIncreased
     | CounterDecreased
-    deriving (Show, Generic, ToJSON, FromJSON)
+    deriving (Show, Generic, ToJSON, FromJSON, NFData)
 
 --------------------------------------------------------------------------------
 -- Define event handler

--- a/domaindriven-examples/postgres/Event/V1.hs
+++ b/domaindriven-examples/postgres/Event/V1.hs
@@ -1,5 +1,6 @@
 module Event.V1 where
 
+import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
 import Prelude
@@ -7,4 +8,4 @@ import Prelude
 data CounterEvent
     = CounterIncreased
     | CounterDecreased
-    deriving (Show, Generic, FromJSON, ToJSON)
+    deriving (Show, Generic, FromJSON, ToJSON, NFData)

--- a/domaindriven-examples/postgres/Event/V2.hs
+++ b/domaindriven-examples/postgres/Event/V2.hs
@@ -1,5 +1,6 @@
 module Event.V2 where
 
+import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
 import Prelude
@@ -7,4 +8,4 @@ import Prelude
 data CounterEvent
     = CounterIncreasedBy Int
     | CounterDecreasedBy Int
-    deriving (Show, Generic, FromJSON, ToJSON)
+    deriving (Show, Generic, FromJSON, ToJSON, NFData)

--- a/domaindriven-examples/simple/Main.hs
+++ b/domaindriven-examples/simple/Main.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 module Main where
 
+import Control.DeepSeq (NFData)
 import Control.Monad (when)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Time (UTCTime)
@@ -39,7 +40,7 @@ data CounterModel = CounterModel
 data CounterEvent
     = CounterIncreased
     | CounterDecreased
-    deriving (Show, Generic, ToJSON, FromJSON)
+    deriving (Show, Generic, ToJSON, FromJSON, NFData)
 
 --------------------------------------------------------------------------------
 -- Define event handler

--- a/domaindriven/domaindriven.cabal
+++ b/domaindriven/domaindriven.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.12
 name:           domaindriven
-version:        0.5.0
+version:        0.6.0
 synopsis:       Batteries included event sourcing and CQRS
 description:    Please see the README on GitHub at <https://github.com/tommyengstrom/domaindriven#readme>
 category:       Web
@@ -113,6 +113,7 @@ test-suite domaindriven-test
     test
   build-depends:
       base
+    , deepseq
     , domaindriven-core
     , domaindriven
     , effectful-core

--- a/domaindriven/test/DomainDriven/InMemorySpec.hs
+++ b/domaindriven/test/DomainDriven/InMemorySpec.hs
@@ -10,12 +10,14 @@ import Effectful
 import Test.Hspec
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.DeepSeq (NFData)
+import GHC.Generics (Generic)
 import Prelude
 
 type TestModel = Int
 
 data TestEvent = AddOne | SubtractOne | Reset
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic, NFData)
 
 applyTestEvent :: TestModel -> Stored TestEvent -> TestModel
 applyTestEvent m ev = case storedEvent ev of

--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,10 @@
           ];
 
           buildInputs = [
-            pkgs.fish
             ghc
             pkgs.cabal-install
+            pkgs.process-compose
+            pkgs.haskell.packages.ghc9103.ghcid
             pkgs.haskell.packages.ghc9103.haskell-language-server
             pkgs.haskell.packages.ghc9103.hspec-discover
             pkgs.zlib.dev
@@ -30,14 +31,30 @@
             pkgs.libpq
           ];
 
-          SHELL = "${pkgs.fish}/bin/fish";
-
-          shellHook = ''
-            export PKG_CONFIG_PATH="${pkgs.xz.dev}/lib/pkgconfig:${pkgs.zlib.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
-            export LIBRARY_PATH="${pkgs.xz.out}/lib:${pkgs.zlib.out}/lib:${pkgs.gmp.out}/lib:${pkgs.libpq.out}/lib:$LIBRARY_PATH"
-            export LD_LIBRARY_PATH="${pkgs.xz.out}/lib:${pkgs.zlib.out}/lib:${pkgs.gmp.out}/lib:${pkgs.libpq.out}/lib:$LD_LIBRARY_PATH"
-            exec ${pkgs.fish}/bin/fish
-          '';
+          env = {
+            PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" [
+              pkgs.xz.dev
+              pkgs.zlib.dev
+            ];
+            C_INCLUDE_PATH = pkgs.lib.makeSearchPath "include" [
+              pkgs.xz.dev
+              pkgs.zlib.dev
+              pkgs.gmp.dev
+              pkgs.libpq.dev
+            ];
+            LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+              pkgs.xz.out
+              pkgs.zlib.out
+              pkgs.gmp.out
+              pkgs.libpq.out
+            ];
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+              pkgs.xz.out
+              pkgs.zlib.out
+              pkgs.gmp.out
+              pkgs.libpq.out
+            ];
+          };
         };
       });
 }

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -1,0 +1,51 @@
+# Haskell graph:
+#   1-deps-cabal -> 2-cabal-build-all -> 3-cabal-test-all
+#                                      -> 3-cabal-benchmark-all
+#                -> 2-ghcid              <- live feedback
+version: "0.5"
+log_location: ./.pc-logs
+processes:
+  0-keepalive:
+    # Never exits, so process-compose stays open when one-shot processes finish
+    # or fail. This leaves logs available for inspection.
+    command: "bash -c 'while true; do sleep 3600; done'"
+    availability:
+      restart: always
+
+  1-deps-cabal:
+    command: "cabal update && cabal build all --only-dependencies --enable-tests --enable-benchmarks -O0"
+    availability:
+      restart: "no"
+
+  2-cabal-build-all:
+    command: "cabal build all --enable-tests --enable-benchmarks -O0"
+    availability:
+      restart: "no"
+    depends_on:
+      1-deps-cabal:
+        condition: process_completed_successfully
+
+  2-ghcid:
+    command: "./run-ghcid.sh"
+    is_tty: true
+    depends_on:
+      1-deps-cabal:
+        condition: process_completed_successfully
+
+  3-cabal-test-all:
+    command: "cabal test all -O0"
+    is_tty: true
+    availability:
+      restart: "no"
+    depends_on:
+      2-cabal-build-all:
+        condition: process_completed_successfully
+
+  3-cabal-benchmark-all:
+    command: "cabal bench all -O0"
+    is_tty: true
+    availability:
+      restart: "no"
+    depends_on:
+      2-cabal-build-all:
+        condition: process_completed_successfully

--- a/skills/domaindriven/SKILL.md
+++ b/skills/domaindriven/SKILL.md
@@ -44,15 +44,16 @@ emptyLibraryModel :: LibraryModel
 emptyLibraryModel = LibraryModel mempty
 
 -- 3. Hierarchical events with entity IDs (see event-design.md)
+--    Every event type must derive NFData (import Control.DeepSeq (NFData)).
 data LibraryEvent
     = BookEvent { bookId :: BookId, bookEvent :: BookEvent }
-    deriving (Generic, ToJSON, FromJSON)
+    deriving (Generic, ToJSON, FromJSON, NFData)
 
 data BookEvent
     = BookAdded { title :: Text, author :: Text }
     | BookRemoved
     | TitleChanged { title :: Text }
-    deriving (Generic, ToJSON, FromJSON)
+    deriving (Generic, ToJSON, FromJSON, NFData)
 
 -- 4. Apply events with optics (see event-design.md for full dispatch)
 applyEvent :: LibraryModel -> Stored LibraryEvent -> LibraryModel

--- a/skills/domaindriven/event-design.md
+++ b/skills/domaindriven/event-design.md
@@ -1,5 +1,11 @@
 # Event Design Principles
 
+> **Required instances:** every event type (at every level of the hierarchy)
+> must derive `NFData` in addition to `ToJSON`/`FromJSON`. The persistence layer
+> forces parsed events with `deepseq`, and the requirement is enforced uniformly
+> across all backends via a superclass on `ReadModel`. `deriving (Generic,
+> ToJSON, FromJSON, NFData)` covers it (`import Control.DeepSeq (NFData)`).
+
 ## Small Events
 
 Each event should capture exactly one fact. If a command does multiple things, emit multiple events.
@@ -28,7 +34,7 @@ Use a sum-of-sums pattern for the top-level event type. Each level wraps the nex
 -- Top-level event (what gets stored)
 data LibraryEvent
     = BookEvent { bookId :: BookId, bookEvent :: BookEvent }
-    deriving (Generic, ToJSON, FromJSON)
+    deriving (Generic, ToJSON, FromJSON, NFData)
 
 -- Book-level events
 data BookEvent
@@ -37,14 +43,14 @@ data BookEvent
     | TitleChanged { title :: Text }
     | AuthorChanged { author :: Text }
     | ChapterEvent { chapterId :: ChapterId, chapterEvent :: ChapterEvent }
-    deriving (Generic, ToJSON, FromJSON)
+    deriving (Generic, ToJSON, FromJSON, NFData)
 
 -- Chapter-level events (3rd level)
 data ChapterEvent
     = ChapterAdded { title :: Text, pageCount :: Int }
     | ChapterRemoved
     | ChapterTitleChanged { title :: Text }
-    deriving (Generic, ToJSON, FromJSON)
+    deriving (Generic, ToJSON, FromJSON, NFData)
 ```
 
 ### Benefits

--- a/skills/domaindriven/project-setup.md
+++ b/skills/domaindriven/project-setup.md
@@ -36,12 +36,12 @@ my-project/
 ### `<project>-events`
 Canonical, current event types. This is the only package you edit when changing events. Events live in a separate package so the migration package can import frozen snapshots at each version — without the split, you can't have two versions of the same module in scope at once.
 
-**Must not depend on the main service package.** Keep dependencies minimal — typically just `aeson`, `text`, `time`, and similar leaf libraries. The events package defines pure data types; it should not pull in Servant, Effectful, database libraries, or anything heavy.
+**Must not depend on the main service package.** Keep dependencies minimal — typically just `aeson`, `deepseq`, `text`, `time`, and similar leaf libraries. Every event type must derive `NFData`, so the package that defines current events needs a direct `deepseq` dependency. The events package defines pure data types; it should not pull in Servant, Effectful, database libraries, or anything heavy.
 
 **All types referenced by event field definitions live here too** — domain primitives, value objects, enums, newtypes. If an event field uses `Email` or `PhoneNumber`, those types belong in `<project>-events`, not in the main service package. Otherwise handlers end up wrapping/unwrapping shims to convert between "the service's `Email`" and "the event's `Email`", and migrations get harder because the frozen snapshots can't see the current domain types.
 
 ### `<project>-migrations`
-**Must not depend on the main service package.** Dependencies should be limited to `<project>-events`, `domaindriven-core`, `shape-coerce`, and basic libraries. Keeping this package lightweight ensures fast compilation of migration logic.
+**Must not depend on the main service package.** Dependencies should be limited to `<project>-events`, `domaindriven-core`, `shape-coerce`, `deepseq`, and basic libraries. Frozen event snapshots also derive `NFData`, so the migrations package needs `deepseq` when it owns those snapshot modules. Keeping this package lightweight ensures fast compilation of migration logic.
 
 Two kinds of modules:
 - **Event snapshots** (`EventN.*`): Frozen copies of `<project>-events` at version N. Created by copying all modules from `<project>-events` into an `EventN.*` namespace.


### PR DESCRIPTION
- Add configurable parse concurrency and default it to CPU capabilities.
- Parse fetched event rows in parallel while preserving input order.
- Switch event columns to `event::text` and decode from strict bytestrings.
- Refactor migration streaming to keep per-index state in an `IORef`.
- Add tests for ordered parallel parsing and first-error reporting.
- Add a benchmark and update Cabal/Nix build inputs for the new tooling.
