### PR TITLE
Fix JsonObject schema marking Maybe fields as required

### DIFF
--- a/domaindriven/src/DomainDriven/Server/Api.hs
+++ b/domaindriven/src/DomainDriven/Server/Api.hs
@@ -110,6 +110,7 @@ instance
     , ToSchema (JsonObject fields)
     , ToSchema t
     , KnownSymbol name
+    , IsOptional t
     )
     => ToSchema (JsonObject ('NamedField name t ': fields))
     where


### PR DESCRIPTION
The `ToSchema (JsonObject ('NamedField name t ': fields))` instance already branches on `isOptional @t`, but `IsOptional t` was not in the instance context — so GHC solved the constraint at the instance definition site, where `t` is a rigid type variable. A rigid variable can't match the `IsOptional (Maybe t)` instance, so the `OVERLAPPABLE` catch-all (`False`) was always selected and every field, `Maybe` or not, landed in the schema's `required` list.

This PR adds `IsOptional t` to the instance context, deferring resolution to the use site where `t` is concrete. `Maybe` fields now render as optional.

Verified end-to-end against the eir claims API (which pins this branch at 99f62b3): request bodies with `Maybe` fields — e.g. `reportToFossAs :: Maybe FossIncidentType` on claim-type create — now generate `required` lists containing only the non-`Maybe` fields, and the full claims test suite passes against the patched library (235 examples, 0 failures).

Targeting `old-upgraded` since that's the branch the claims repo pins (master no longer carries `JsonObject`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)